### PR TITLE
tag/branch support won't work with go-import

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,8 +38,11 @@ paths:
     redir: https://github.com/golift/unifi
     cache_max_age: 2345
   /deluge:
-    repo: https://github.com/golift/deluge
+    repo: https://code.golift.io/deluge
     redir: https://github.com/golift/deluge
+    vcs: git
+    redir_paths: [""]
+
   /imessage:
     repo: https://github.com/golift/imessage
     redir: https://github.com/golift/imessage
@@ -58,6 +61,13 @@ paths:
   /securityspy:
     repo: https://github.com/golift/securityspy
     redir: https://github.com/golift/securityspy
+
+  /sspy:
+    tags:
+      v1: v1
+      v2: v2
+      v3: 6209cbf016e87855484aa280b25ffa2cfba3fc3e
+    repo: https://github.com/golift/securityspy
 
   # Unused Examples.
   /david/:

--- a/handler_test.go
+++ b/handler_test.go
@@ -154,6 +154,18 @@ func TestHandler(t *testing.T) {
 			goSource: "example.com/rakyllrepo https://github.com/rakyll/repo https://github.com/rakyll/repo/tree/master{/dir} https://github.com/rakyll/repo/blob/master{/dir}/{file}#L{line}",
 		},
 		{
+			name: "tag on the end",
+			config: "host: example.com\n" +
+				"paths:\n" +
+				"  /portmidi:\n" +
+				"    repo: https://gitlab.com/rakyll/portmidi\n" +
+				"    tags:\n" +
+				"      v1: sha_goes_here\n",
+			path:     "/portmidi.v1",
+			goImport: "example.com/portmidi.v1 git https://gitlab.com/rakyll/portmidi",
+			goSource: "example.com/portmidi.v1 _ https://gitlab.com/rakyll/portmidi/tree/sha_goes_here{/dir} https://gitlab.com/rakyll/portmidi/blob/sha_goes_here{/dir}/{file}#L{line}",
+		},
+		{
 			name: "display Gitlab inference",
 			config: "host: example.com\n" +
 				"paths:\n" +


### PR DESCRIPTION
I tried to make `.v2` type support work (gopkg.in), but the `go-import` meta tag doesn't work with branches. Bummer. Leaving this here for a while, until I decide I want to tackle re-writing `refs` responses.